### PR TITLE
Add Search bar and heading in Nodes Sidebar

### DIFF
--- a/components/ui-sidebar/sidebar.tsx
+++ b/components/ui-sidebar/sidebar.tsx
@@ -9,7 +9,7 @@ import Cross1 from '@/components/radix/cross1';
 import { Categories } from './categories-collapsible';
 import NodeButton from './node-button';
 import React, { useState } from 'react';
-import { Search } from "lucide-react"
+import { Input } from '@/components/ui/input';
 
 
 export default function Sidebar() {
@@ -54,14 +54,13 @@ export default function Sidebar() {
                         <Cross1 />
                     </CardHeader>
 
-                    <div className="flex items-center rounded-md border px-4 py-2 shadow-sm text-sm mx-4 mb-2">
-                        <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
-                        <input
+                    <div className='pb-2'>
+                        <Input
                             type="text"
                             placeholder="Search"
                             value={searchTerm}
                             onChange={(e) => setSearchTerm(e.target.value)}
-                            className="outline-none"
+                            className="items-center px-7 py-2 mx-4"
                         />
                     </div>
 

--- a/components/ui-sidebar/sidebar.tsx
+++ b/components/ui-sidebar/sidebar.tsx
@@ -8,7 +8,13 @@ import {
 import Cross1 from '@/components/radix/cross1';
 import { Categories } from './categories-collapsible';
 
+import {
+    Command,
+    CommandInput,
+} from '@/components/ui/command';
+
 export default function Sidebar() {
+
     const AvailableNodes = [
         {
             id: 'source-node',
@@ -39,8 +45,18 @@ export default function Sidebar() {
             <ResizablePanel className="min-w-fit" defaultSize={1}>
                 <Card className="max-h-[calc(100vh-2rem)] flex flex-col">
                     <CardHeader className="flex flex-row items-center justify-between">
-                        <CardTitle>Nodes</CardTitle>
+                        <CardTitle className="text-3xl font-bold">Nodes</CardTitle>
                         <Cross1 />
+                    </CardHeader>
+
+                    <div className="flex justify-center px-4 pb-2">
+                        <Command className=" rounded-lg border shadow-none">
+                            <CommandInput placeholder="Search" />
+                        </Command>
+                    </div>
+
+                    <CardHeader className="flex flex-row items-center justify-between">
+                        <CardTitle className="text-2xl font-bold">Recent</CardTitle>
                     </CardHeader>
 
                     <CardContent className="overflow-y-auto flex-1">

--- a/components/ui-sidebar/sidebar.tsx
+++ b/components/ui-sidebar/sidebar.tsx
@@ -65,7 +65,7 @@ export default function Sidebar() {
                         />
                     </div>
 
-                    <CardContent className="overflow-y-auto flex-1 ">
+                    <CardContent className="overflow-y-auto flex-1 flex flex-col gap-1">
                         {searchTerm &&
                             filteredNodes.map((node) => (
                                 <NodeButton

--- a/components/ui-sidebar/sidebar.tsx
+++ b/components/ui-sidebar/sidebar.tsx
@@ -76,7 +76,7 @@ export default function Sidebar() {
                             ))}
                     </CardContent>
 
-                    <CardHeader className="pt-0">Recent</CardHeader>
+                    <CardHeader className="pt-0 pb-2">Recent</CardHeader>
 
                     <CardContent className="overflow-y-auto flex-1">
                         <div>

--- a/components/ui-sidebar/sidebar.tsx
+++ b/components/ui-sidebar/sidebar.tsx
@@ -7,11 +7,10 @@ import {
 } from '@/components/ui/resizable';
 import Cross1 from '@/components/radix/cross1';
 import { Categories } from './categories-collapsible';
+import NodeButton from './node-button';
+import React, { useState } from 'react';
+import { Search } from "lucide-react"
 
-import {
-    Command,
-    CommandInput,
-} from '@/components/ui/command';
 
 export default function Sidebar() {
 
@@ -36,6 +35,12 @@ export default function Sidebar() {
         },
     ];
 
+    const [searchTerm, setSearchTerm] = useState('');
+
+    const filteredNodes = AvailableNodes.filter((node) =>
+        node.label.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+
     const uniqueCategories = [
         ...new Set(AvailableNodes.map((node) => node.category)),
     ];
@@ -45,19 +50,34 @@ export default function Sidebar() {
             <ResizablePanel className="min-w-fit" defaultSize={1}>
                 <Card className="max-h-[calc(100vh-2rem)] flex flex-col">
                     <CardHeader className="flex flex-row items-center justify-between">
-                        <CardTitle className="text-3xl font-bold">Nodes</CardTitle>
+                        <CardTitle>Nodes</CardTitle>
                         <Cross1 />
                     </CardHeader>
 
-                    <div className="flex justify-center px-4 pb-2">
-                        <Command className=" rounded-lg border shadow-none">
-                            <CommandInput placeholder="Search" />
-                        </Command>
+                    <div className="flex items-center rounded-md border px-4 py-2 shadow-sm text-sm mx-4 mb-2">
+                        <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+                        <input
+                            type="text"
+                            placeholder="Search"
+                            value={searchTerm}
+                            onChange={(e) => setSearchTerm(e.target.value)}
+                            className="outline-none"
+                        />
                     </div>
 
-                    <CardHeader className="flex flex-row items-center justify-between">
-                        <CardTitle className="text-2xl font-bold">Recent</CardTitle>
-                    </CardHeader>
+                    <CardContent className="overflow-y-auto flex-1 ">
+                        {searchTerm &&
+                            filteredNodes.map((node) => (
+                                <NodeButton
+                                    key={node.id}
+                                    id={node.id}
+                                    label={node.label}
+                                    description={node.description}
+                                />
+                            ))}
+                    </CardContent>
+
+                    <CardHeader className="pt-0">Recent</CardHeader>
 
                     <CardContent className="overflow-y-auto flex-1">
                         <div>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
     return (
         <div className="relative flex items-center">
-            <MagnifyingGlassIcon className="absolute left-3 text-[#96bdba]" />
+            <MagnifyingGlassIcon className="absolute left-6 text-[#96bdba]" />
             <input
                 type={type}
                 className={cn(


### PR DESCRIPTION
## What?

Added 'Recent' heading and search bar to the Nodes sidebar. It currently searches through nodes by label and displays filtered nodes below search bar.

---

## How?

Inserted a heading for 'Recent' using CardHeader component to label the section. 

Implemented a search bar with a search icon using Input component. Made slight change to Input component to fix position of the icon. The user input updates the searchTerm state which I added. This filters the AvailableNodes array based on searchTerm and node label to a new array filteredNodes, which is then displayed under the search bar by mapping each node as a NodeButton.

---

## Testing

- Verified that the 'Recent' heading is displayed correctly above the node categories.
- Manually typed in the search bar to confirm it updates the searchTerm state.
- Ensured styling and spacing matched the rest of the UI (including padding and margin).
